### PR TITLE
Automated cherry pick of #52: fix: add api_server configuration to ocboot installation

### DIFF
--- a/docs/getting-started/_parts/_quickstart-ocboot-install-cloudpods.mdx
+++ b/docs/getting-started/_parts/_quickstart-ocboot-install-cloudpods.mdx
@@ -32,3 +32,9 @@ Password: admin@123
 然后用浏览器访问 https://10.168.26.216 ，用户名输入 `admin`，密码输入 `admin@123` 就会进入 Cloudpods 的界面。
 
 ![登录页](../images/index.png)
+
+## 修改 api_server 接入端
+
+`api_server` 配置是整个平台的接入端地址，会影响前端 CloudShell、 虚拟机 VNC 或者 Web SSH 的连接。一般无法打开 CloudShell 或者通过前端 SSH 进入虚拟机，是因为没有正确设置 api_server 配置。
+
+需要参考文档：[修改服务 api_server 入口配置](../../operations/fe/config-ssl-certs#change-api-server-via-climc)，根据自己环境的网络情况手动修改。

--- a/docs/getting-started/cmp/quickstart-k8s-helm.md
+++ b/docs/getting-started/cmp/quickstart-k8s-helm.md
@@ -217,8 +217,9 @@ default-cloudpods-web   *       10.127.100.207          80, 443   7h52m
 
 ## 修改 api_server 接入端
 
-api_server 是整个平台的接入端地址，会影响前端 vnc 或者 web ssh 的连接。
-需要根据自己的环境手动修改，参考文档：[修改服务 api_server 入口配置](../../operations/fe/config-ssl-certs#change-api-server-via-climc)。
+`api_server` 配置是整个平台的接入端地址，会影响前端 CloudShell、 虚拟机 VNC 或者 Web SSH 的连接。一般无法打开 CloudShell 或者通过前端 SSH 进入虚拟机，是因为没有正确设置 api_server 配置。
+
+需要参考文档：[修改服务 api_server 入口配置](../../operations/fe/config-ssl-certs#change-api-server-via-climc)，根据自己环境的网络情况手动修改。
 
 ## 升级
 

--- a/docs/getting-started/cmp/quickstart-ocboot.md
+++ b/docs/getting-started/cmp/quickstart-ocboot.md
@@ -44,7 +44,6 @@ import UseCMP from '../_parts/_quickstart-use-cmp.mdx';
 
 ## FAQ
 
-
 ### 1. 如何重装?
 
 import FAQReset from '../_parts/_quickstart-faq-reset.md';

--- a/i18n/en/docusaurus-plugin-content-docs/current/getting-started/_parts/_quickstart-ocboot-install-cloudpods.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/getting-started/_parts/_quickstart-ocboot-install-cloudpods.mdx
@@ -32,3 +32,10 @@ Password: admin@123
 Then use a browser to access https://10.168.26.216. Enter `admin` for username and `admin@123` for password to enter the Cloudpods interface.
 
 ![login page](../images/index.png)
+
+## Change the api_server access url
+
+The `api_server` option is the address of the access point for the entire platform, which affects the front-end CloudShell, vnc or Web SSH connection. It is generally impossible to open CloudShell or login the virtual machine through the front-end SSH when the api_server configuration has not been set correctly.
+
+You need to modify it manually according to your environment, refer to the document: [Change service api_server configuration](../../operations/fe/config-ssl-certs#change-api-server-via-climc).
+

--- a/i18n/en/docusaurus-plugin-content-docs/current/getting-started/cmp/quickstart-k8s-helm.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/getting-started/cmp/quickstart-k8s-helm.md
@@ -214,7 +214,8 @@ Visit the platform frontend at https://10.127.100.207 using a browser, and then 
 
 ## Change the api_server access url
 
-The api_server is the address of the access point for the entire platform, which affects the front-end vnc or web ssh connection.
+The `api_server` option is the address of the access point for the entire platform, which affects the front-end vnc or web ssh connection.
+
 You need to modify it manually according to your environment, refer to the document: [Change service api_server configuration](../../operations/fe/config-ssl-certs#change-api-server-via-climc).
 
 ## Upgrade


### PR DESCRIPTION
Cherry pick of #52 on master.

#52: fix: add api_server configuration to ocboot installation