### PR TITLE
redirect some old urls

### DIFF
--- a/static/en/docs/swagger/index.html
+++ b/static/en/docs/swagger/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <script>
+    window.location.href = `https://apifox.com/apidoc/shared-f917f6a6-db9f-4d6a-bbc3-ea58c945d7fd`
+  </script>
+</html>
+

--- a/static/zh/docs/quickstart/allinone-converge/index.html
+++ b/static/zh/docs/quickstart/allinone-converge/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <script>
+    window.location.href = `${window.location.origin}/docs/getting-started/full/quickstart-full`
+  </script>
+</html>

--- a/static/zh/docs/quickstart/docker-compose/index.html
+++ b/static/zh/docs/quickstart/docker-compose/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <script>
+    window.location.href = `${window.location.origin}/docs/getting-started/cmp/quickstart-docker-compose`
+  </script>
+</html>

--- a/static/zh/docs/quickstart/k8s/index.html
+++ b/static/zh/docs/quickstart/k8s/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <script>
+    window.location.href = `${window.location.origin}/docs/getting-started/cmp/quickstart-k8s-helm`
+  </script>
+</html>
+

--- a/static/zh/docs/setup/ha-ce/index.html
+++ b/static/zh/docs/setup/ha-ce/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <script>
+    window.location.href = `${window.location.origin}/docs/getting-started/onpremise/ha-ce`
+  </script>
+</html>

--- a/static/zh/docs/setup/upgrade/index.html
+++ b/static/zh/docs/setup/upgrade/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <script>
+    window.location.href = `${window.location.origin}/docs/operations/upgrading/ocboot-upgrade`
+  </script>
+</html>
+

--- a/static/zh/docs/swagger/index.html
+++ b/static/zh/docs/swagger/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <script>
+    window.location.href = `https://apifox.com/apidoc/shared-f917f6a6-db9f-4d6a-bbc3-ea58c945d7fd`
+  </script>
+</html>
+

--- a/static/zh/index.html
+++ b/static/zh/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <script>
+    window.location.href = window.location.origin.replace('/zh', '')
+  </script>
+</html>
+


### PR DESCRIPTION
重定向 https://v1.cloudpods.org 一些之前常用的 url 。

没有用 https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-client-redirects 的原因是这个插件只支持已有文档的 url 重定向。