### PR TITLE
Automated cherry pick of #176: fix: 表格设置默认高度改为最大高度,防止内容不够的表格产生多余空间

### DIFF
--- a/src/components/CloudFeatureSupport/styles.module.css
+++ b/src/components/CloudFeatureSupport/styles.module.css
@@ -3,7 +3,7 @@
 }
 
 table tr th, table tr td  { border-left: 1px solid #dee2e6 }
-table { border-collapse: collapse; table-layout:fixed; width:100%; height: 700px; }
+table { border-collapse: collapse; table-layout:fixed; width:100%; max-height: 700px; }
 .fixed-row-1 { position:sticky; top: 0; background-color: #FFFFFF; z-index: 2 }
 .fixed-row-2 { position:sticky; top: 48px; background-color: #fff; z-index: 2 }
 .fixed-col-1 { position:sticky; left: 0; background-color: #FFFFFF; z-index: 1 }


### PR DESCRIPTION
Cherry pick of #176 on release/3.11.

#176: fix: 表格设置默认高度改为最大高度,防止内容不够的表格产生多余空间