### PR TITLE
Automated cherry pick of #405: fix: update ocboot_release_version to master-v3.11.8-3

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,7 +16,7 @@ const config = {
     pre_release_branch: 'release/3.10',
     release_version: 'v3.11.8',
     pre_release_version: 'v3.10.15',
-    ocboot_release_version: 'master-v3.11.8-2',
+    ocboot_release_version: 'master-v3.11.8-3',
   },
 
   // Set the production url of your site here


### PR DESCRIPTION
Cherry pick of #405 on master.

#405: fix: update ocboot_release_version to master-v3.11.8-3