### PR TITLE
Automated cherry pick of #441: fix: change ocboot_release_version to master-v3.11.11-1

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,7 +16,7 @@ const config = {
     pre_release_branch: 'release/3.10',
     release_version: 'v3.11.11',
     pre_release_version: 'v3.10.15',
-    ocboot_release_version: 'master-v3.11.11-0',
+    ocboot_release_version: 'master-v3.11.11-1',
   },
 
   // Set the production url of your site here


### PR DESCRIPTION
Cherry pick of #441 on master.

#441: fix: change ocboot_release_version to master-v3.11.11-1