### PR TITLE
Automated cherry pick of #585: set ocboot_release_version to master-v4.0.2-4

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,7 +13,7 @@ const config = {
     pre_release_branch: 'release/3.11',
     release_version: 'v4.0.2',
     pre_release_version: 'v3.11.13',
-    ocboot_release_version: 'master-v4.0.2-3',
+    ocboot_release_version: 'master-v4.0.2-4',
   },
 
   url: process.env.DOCUSAURUS_URL || 'https://www.cloudpods.org',


### PR DESCRIPTION
Cherry pick of #585 on master.

#585: set ocboot_release_version to master-v4.0.2-4