### PR TITLE
fix(i18n): update English version label from 3.11 to 4.0

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs-baremetal/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs-baremetal/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "3.11",
+    "message": "4.0",
     "description": "The label for version current"
   },
   "sidebar.baremetalSidebar.category.产品介绍": {

--- a/i18n/en/docusaurus-plugin-content-docs-cmp/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs-cmp/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "3.11",
+    "message": "4.0",
     "description": "The label for version current"
   },
   "sidebar.cmpSidebar.category.产品介绍": {

--- a/i18n/en/docusaurus-plugin-content-docs-onpremise/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs-onpremise/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "3.11",
+    "message": "4.0",
     "description": "The label for version current"
   },
   "sidebar.onpremiseSidebar.category.产品介绍": {

--- a/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "3.11",
+    "message": "4.0",
     "description": "The label for version current"
   },
   "sidebar.tutorialSidebar.category.Getting Started": {


### PR DESCRIPTION
The English i18n files for docs, onpremise, cmp, and baremetal plugins still had version.label set to "3.11", causing the English site version dropdown to show 3.11 instead of 4.0.