### PR TITLE
Automated cherry pick of #616: fix: add ubuntu 26.04 LTS images

### DIFF
--- a/static/openimages.yaml
+++ b/static/openimages.yaml
@@ -64,6 +64,27 @@
 - distribution: Ubuntu Server
   os_name: Linux
   os_arch: x86_64
+  os_version: 26.04(Resolute)
+  build: current
+  source: cloud-images.ubuntu.com
+  url: https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-amd64.img
+- distribution: Ubuntu Server
+  os_name: Linux
+  os_arch: aarch64
+  os_version: 26.04(Resolute)
+  build: current
+  source: cloud-images.ubuntu.com
+  url: https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-arm64.img
+- distribution: Ubuntu Server
+  os_name: Linux
+  os_arch: riscv64
+  os_version: 26.04(Resolute)
+  build: current
+  source: cloud-images.ubuntu.com
+  url: https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-riscv64.img
+- distribution: Ubuntu Server
+  os_name: Linux
+  os_arch: x86_64
   os_version: 25.04(Plucky)
   build: current
   source: cloud-images.ubuntu.com


### PR DESCRIPTION
Cherry pick of #616 on release/4.0.

#616: fix: add ubuntu 26.04 LTS images