### PR TITLE
chore(static): 新增多款 LLM 桌面应用镜像配置

### DIFF
--- a/static/llmimages.yaml
+++ b/static/llmimages.yaml
@@ -28,3 +28,75 @@
     profile: selkies
     default_port: 3001
     protocol: https
+- image: registry.cn-beijing.aliyuncs.com/cloudpods/weixin:180e26d4-ls27
+  description: WeChat desktop
+  llm_type: desktop
+  app_name: weixin
+  desktop:
+    ui_title: Cloudpods WeChat
+    profile: selkies
+    default_port: 3001
+    protocol: https
+- image: registry.cn-beijing.aliyuncs.com/cloudpods/vscode:1.122.1-ls9
+  description: Visual Studio Code desktop
+  llm_type: desktop
+  app_name: vscode
+  desktop:
+    ui_title: Cloudpods VS Code
+    profile: selkies
+    default_port: 3001
+    protocol: https
+- image: registry.cn-beijing.aliyuncs.com/cloudpods/wps-office:11.1.0.11723-2-ls171
+  description: WPS Office desktop
+  llm_type: desktop
+  app_name: wps-office
+  desktop:
+    ui_title: Cloudpods WPS Office
+    profile: selkies
+    default_port: 3001
+    protocol: https
+- image: registry.cn-beijing.aliyuncs.com/cloudpods/steam:b6afafe3-ls25
+  description: Steam desktop
+  llm_type: desktop
+  app_name: steam
+  desktop:
+    ui_title: Cloudpods Steam
+    profile: selkies
+    default_port: 3001
+    protocol: https
+- image: registry.cn-beijing.aliyuncs.com/cloudpods/webtop:ubuntu-xfce-version-be8fdec1
+  description: Ubuntu XFCE desktop (LinuxServer webtop)
+  llm_type: desktop
+  app_name: ubuntu-xfce
+  desktop:
+    ui_title: Cloudpods Ubuntu XFCE
+    profile: selkies
+    default_port: 3001
+    protocol: https
+- image: registry.cn-beijing.aliyuncs.com/cloudpods/webtop:ubuntu-kde-version-386ae438
+  description: Ubuntu KDE desktop (LinuxServer webtop)
+  llm_type: desktop
+  app_name: ubuntu-kde
+  desktop:
+    ui_title: Cloudpods Ubuntu KDE
+    profile: selkies
+    default_port: 3001
+    protocol: https
+- image: registry.cn-beijing.aliyuncs.com/cloudpods/webtop:fedora-kde-version-06d34634
+  description: Fedora KDE desktop (LinuxServer webtop)
+  llm_type: desktop
+  app_name: fedora-kde
+  desktop:
+    ui_title: Cloudpods Fedora KDE
+    profile: selkies
+    default_port: 3001
+    protocol: https
+- image: registry.cn-beijing.aliyuncs.com/cloudpods/webtop:fedora-xfce-version-a3d1e044
+  description: Fedora XFCE desktop (LinuxServer webtop)
+  llm_type: desktop
+  app_name: fedora-xfce
+  desktop:
+    ui_title: Cloudpods Fedora XFCE
+    profile: selkies
+    default_port: 3001
+    protocol: https


### PR DESCRIPTION
补充微信、VS Code、WPS、Steam 及 Ubuntu/Fedora webtop 桌面镜像条目。